### PR TITLE
Fix deleting answer

### DIFF
--- a/js/upvotes.js
+++ b/js/upvotes.js
@@ -1,47 +1,24 @@
-$(document).ready(function() {
-    const DEBUG = false;
+const DEBUG = false;
 
-    /**
-     * debugging function
-     *
-     * prints {msg}(any) to the console
-     */
-    function d(msg) {
-        if (DEBUG) console.log(msg);
+/**
+ * debugging function
+ *
+ * prints {msg}(any) to the console
+ */
+function d(msg) {
+    if (DEBUG) {
+        // add "quora upvotes" prefix so we can use filtering in debugtools
+        console.log("quora upvotes: " + msg);
     }
+}
 
+$(document).ready(function() {
     var isQuestion = $('h3:contains("Related Questions")').length;
-    d(isQuestion);
-    if ( isQuestion )
-    {
-        d( "is question" );
 
-        $(".overflow_link > a").first().click(function() {
-            d('made it');
-            
-            var sort_btn = "<li id='added_sort_btn' class='menu_list_item'>" +
-            "<span class='light_gray'><span><a href='#'>Sort by Votes</a></span></span></li>";
+    d("is question = " + isQuestion);
 
-            var add_btn_timer = setInterval(function() {
-                var attachTo = $(".overflow_link .menu_list_items").first();
-                d('keep trying to add button');
-                if ( attachTo.find('#added_sort_btn').length > 0 )
-                {
-                    d('already attached');
-                    clearInterval(add_btn_timer);
-                }
-                else
-                {
-                    attachTo.append(sort_btn);
-                    d($('.unified_menu').size());
-                }
-
-                $( "#added_sort_btn" ).click( function() {
-                    sort_questions();
-                });
-            }, 200);
-        });
-        
+    if (isQuestion) {
+        add_sort_btn();
     }
 
     function sort_questions () {
@@ -100,3 +77,33 @@ $(document).ready(function() {
     }
 
 });
+
+// This function adds a sort button to the question dropdown list.
+function add_sort_btn() {
+    $(".overflow_link > a").first().click(function() {
+        // only try to add sort_btn when it is not yet added
+        if (!$("#added_sort_btn").length) {
+            // set a timer to repeatedly trying to add the sort_btn because sometimes
+            // Quora is not able able to render the dropdown menu by the time we try
+            // to add the sort_btn, thus we keep trying until finally added the btn.
+            var add_btn_timer = setInterval(function() {
+                d('keep trying to add sort_btn');
+
+                // find the dropdown menu
+                var attachTo = $(".overflow_link .menu_list_items").first();
+
+                if (attachTo.find('#added_sort_btn').length > 0) {
+                    d('already attached');
+                    clearInterval(add_btn_timer);
+                } else {
+                    d('adding sort_btn');
+                    var sort_btn = "<li id='added_sort_btn' class='menu_list_item'>" +
+                    "<span class='light_gray'><span><a href='#'>Sort by Votes</a></span></span></li>";
+
+                    attachTo.append(sort_btn);
+                    $("#added_sort_btn").click(sort_questions);
+                }
+            }, 200);
+        }
+    });
+}

--- a/js/upvotes.js
+++ b/js/upvotes.js
@@ -69,7 +69,7 @@ function sort_answers() {
     for (var i = 0; i < shown_answers.length; ++i) {
         shown_answers[i].upvotes = $(shown_answers[i]).find(".count").first().text();
         if (shown_answers[i].upvotes.includes("k")) {
-            shown_answers[i].upvotes = parseInt(shown_answers[i].upvotes) * 1000;
+            shown_answers[i].upvotes = parseFloat(shown_answers[i].upvotes) * 1000;
         }
     }
 

--- a/js/upvotes.js
+++ b/js/upvotes.js
@@ -20,62 +20,6 @@ $(document).ready(function() {
     if (isQuestion) {
         add_sort_btn();
     }
-
-    function sort_questions () {
-        var elts = $( ".AnswerPagedList > .pagedlist_item");
-        var answers = elts
-          .not(".pagedlist_hidden")
-          .toArray();
-        var hidden_answers = $( ".AnswerPagedList > .pagedlist_hidden" );
-
-        d(Array.isArray(answers));
-
-
-            for (var i = 0; i < answers.length; ++i) {
-                answers[i].upvotes = $( answers[i] ).find( ".count" ).first().text();
-
-                if (answers[i].upvotes.includes("k"))
-                    answers[i].upvotes = parseInt(answers[i].upvotes) * 1000;
-            }
-
-
-            if (DEBUG) {
-                for (i = 0; i < answers.length; ++i) {
-                     console.log(answers[i].upvotes);
-                }
-            }
-
-            // sort the oject of answer elements by upvotes
-            answers.sort( function(a, b) {
-                if (DEBUG)
-                {
-                    console.log(typeof a.upvotes);
-                    console.log(a.upvotes);
-                }
-
-                return b.upvotes - a.upvotes;
-            });
-
-            // re render the elements based on upvote sort
-        var ajaxElem = $( ".AnswerPagedList" ).children().not(".pagedlist_item");
-            ajaxElem.detach();
-
-        d("Ajaxy thing: " + String(ajaxElem));
-
-        $( ".AnswerPagedList" ).empty();
-
-        for (i = 0; i < answers.length - 1; ++i) {
-            $( ".AnswerPagedList" ).append( answers[i] );
-        }
-
-        hidden_answers.each(function() {
-          $( ".AnswerPagedList" ).append(this);
-        });
-
-        $( ".AnswerPagedList").append(ajaxElem);
-
-    }
-
 });
 
 // This function adds a sort button to the question dropdown list.
@@ -101,9 +45,46 @@ function add_sort_btn() {
                     "<span class='light_gray'><span><a href='#'>Sort by Votes</a></span></span></li>";
 
                     attachTo.append(sort_btn);
-                    $("#added_sort_btn").click(sort_questions);
+                    $("#added_sort_btn").click(sort_answers);
                 }
             }, 200);
         }
     });
+}
+
+// This function will sort all currently shown answers by upvotes.
+// However, if the question has a lot of answers,
+// which will only be loaded later when users scroll down,
+// then this function will need to be invoked again (somehow).
+function sort_answers() {
+    // find all shown_answers
+    var answers = $(".AnswerPagedList > .pagedlist_item");
+    var shown_answers = answers.not(".pagedlist_hidden");
+
+    shown_answers.detach();
+
+    shown_answers = shown_answers.toArray();
+
+    // find shown_answers' upvotes
+    for (var i = 0; i < shown_answers.length; ++i) {
+        shown_answers[i].upvotes = $(shown_answers[i]).find(".count").first().text();
+        if (shown_answers[i].upvotes.includes("k")) {
+            shown_answers[i].upvotes = parseInt(shown_answers[i].upvotes) * 1000;
+        }
+    }
+
+    // sort the answers by upvotes in decreasing order
+    shown_answers.sort(function(a, b) {
+        return b.upvotes - a.upvotes;
+    });
+
+    for (i = 0; i < shown_answers.length; ++i) {
+        d(shown_answers[i].upvotes);
+    }
+
+    // reinsert the shown_answers based on upvotes
+    // in reverse order because we use before()
+    for (i = shown_answers.length - 1; i >= 0; --i) {
+        $(".AnswerPagedList").children().first().before(shown_answers[i]);
+    }
 }


### PR DESCRIPTION
This pull request tries to resolve issue #2. There are four commits in total.

The first commit fixes the issue of adding the sort_btn onclick function multiple times. Actually, every time users click the dropdown to see "Sort by Upvotes", a new onclick function will be attached to the sort_btn. This will cause problem because the onclick functions will be invoked multiple times (and there is a bug in the original sort_question function, which will delete one answer at a time, thus causing deleting multiple answers).

The second commit fixes exactly the deleting one answer bug. It is in the for loop where we need to iterate from `i = 0` to` i < answers.length` (or` i <= answers.length - 1`), not  `i < answers.length - 1`.

~~The third commit adds a browser action to support sorting answers when users click on the icon. And an extra bonus is, the icon is now colourful in the toolbar! :)~~

The ~~fourth~~ third commit is just a minor change of parseInt to parseFloat as its commit message suggests.
