### PR TITLE
support sorting via browser action

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1,0 +1,7 @@
+// Called when the user clicks on the browser action.
+chrome.browserAction.onClicked.addListener(function(tab) {
+    chrome.tabs.executeScript({
+        // sort_answers is defined in upvotes.js
+        code: 'sort_answers();'
+    });
+});

--- a/manifest.json
+++ b/manifest.json
@@ -15,5 +15,12 @@
     }
   ],
 
+  "background": {
+      "scripts": ["js/background.js"],
+      "persistent": false
+    },
+
+  "browser_action": {},
+
   "permissions": ["*://www.quora.com/*"]
 }


### PR DESCRIPTION
Fixes #4 

As mentioned in the issue description,
>When new answers are loaded to the page, present a fixed position button on the page which says "re-sort" or "sort new answers"

So we can use the icon (i.e. browser action) as the fixed position button.

Although it doesn't say "re-sort", it's natural for users to click on the icon and expect the extension to do something, which is sorting the answers in this case.

Ready for review.